### PR TITLE
WIP: Move to ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/wekinator-node');
+export { Wekinator } from "./lib/wekinator-node";

--- a/lib/wekinator-node.js
+++ b/lib/wekinator-node.js
@@ -1,11 +1,12 @@
-var osc = require('osc');
-var assert = require('assert');
+import osc from "osc";
+import assert from "assert";
 
-var arrayIntsValidation = arrayFloatsValidation = arrayStringsValidation =
-  arg => assert(Array.isArray(arg));
-var numberValidation = number => assert(typeof number === "number");
+const arrayIntsValidation = (arg) => assert(Array.isArray(arg));
+const arrayFloatsValidation = arrayIntsValidation;
+const arrayStringsValidation = arrayIntsValidation;
+const numberValidation = (number) => assert(typeof number === "number");
 
-var methodsToArgValidation = {
+const methodsToArgValidation = {
   outputs: arrayFloatsValidation,
   startRecording: null,
   stopRecording: null,
@@ -24,82 +25,86 @@ var methodsToArgValidation = {
   setOutputNames: arrayStringsValidation,
 };
 
-class Wekinator {
+export class Wekinator {
   constructor(wekinatorHost, wekinatorPort, localPort) {
-    this.host = wekinatorHost || '127.0.0.1';
+    this.host = wekinatorHost || "127.0.0.1";
     this.port = wekinatorPort || 6448;
     this.localPort = localPort || 12000;
-    this.endpoint = '/wekinator';
-    this.controlEndpoint = this.endpoint+'/control';
+    this.endpoint = "/wekinator";
+    this.controlEndpoint = this.endpoint + "/control";
     this.queue = [];
     this.WekaPort = {};
-    this.WekaPort.send = this.WekaPort.on = this.queuePush = function(){
-      throw new Error('Not connected to Wekinator. Please call `.connect()`');
-    };
+    this.WekaPort.send =
+      this.WekaPort.on =
+      this.queuePush =
+        function () {
+          throw new Error(
+            "Not connected to Wekinator. Please call `.connect()`"
+          );
+        };
   }
 
-  connect (callback) {
+  connect(callback) {
     this.WekaPort = new osc.UDPPort({
-      localAddress: '0.0.0.0',
+      localAddress: "0.0.0.0",
       localPort: this.localPort,
       remoteAddress: this.host,
-      remotePort: this.port
+      remotePort: this.port,
     });
     this.WekaPort.open();
 
-    this.queuePush = function(obj){
+    this.queuePush = function (obj) {
       this.queue.push(obj);
       this.queueExec();
     };
 
-    this.queueExec = function(){
-      if(typeof this.queue[0] == "function"){
+    this.queueExec = function () {
+      if (typeof this.queue[0] == "function") {
         this.queue.shift()();
-      }
-      else {
-        this.WekaPort.send(this.queue.shift(),this.host,this.port);
+      } else {
+        this.WekaPort.send(this.queue.shift(), this.host, this.port);
       }
     };
     callback();
-  };
+  }
 
-  on (message, handler){
+  on(message, handler) {
     this.WekaPort.on(message, handler);
-  };
+  }
 
-  disconnect (callback) {
+  disconnect(callback) {
     this.queuePush(() => {
       // I'm so sorry, this is such a hack. It seems to reliably work though.
       setTimeout(() => {
         this.WekaPort.close();
-        if (typeof callback === 'function') {
+        if (typeof callback === "function") {
           callback();
         }
-      },10+5*this.queue.length);
+      }, 10 + 5 * this.queue.length);
     });
-  };
+  }
 
-  inputs (floats) {
+  inputs(floats) {
     assert(Array.isArray(floats));
-    var address = '/wek/inputs';
+    var address = "/wek/inputs";
     this.queuePush({
       address: address,
-      args: floats
+      args: floats,
     });
-  };
+  }
 
-  selectInputsForOutput (output, inputs) {
-    assert(Array.isArray(inputs) && typeof output === 'number');
-    var address = '/selectInputsForOutput';
+  selectInputsForOutput(output, inputs) {
+    assert(Array.isArray(inputs) && typeof output === "number");
+    var address = "/selectInputsForOutput";
     this.queuePush({
-      address: this.controlEndpoint+address,
-      args: [output].concat(inputs)
+      address: this.controlEndpoint + address,
+      args: [output].concat(inputs),
     });
-  };
+  }
 
-  trainOnData (data) {
+  trainOnData(data) {
     this.startRecording();
-    for(var i = 0; i < data.length; i++){
+    for (var i = 0; i < data.length; i++) {
       // We're not *too* worried about the input arriving before the output
       // because we handle queueing internally.
       this.outputs(data[i].outputs);
@@ -107,18 +112,21 @@ class Wekinator {
     }
     this.stopRecording();
     this.train();
-  };
+  }
 }
 
 Wekinator.prototype.close = Wekinator.prototype.disconnect;
 
 Object.entries(methodsToArgValidation).forEach(function ([key, validation]) {
-  Wekinator.prototype[key] = function(arg) {
+  Wekinator.prototype[key] = function (arg) {
     validation && validation(arg);
-    this.queuePush(Object.assign({
-      address: `${this.controlEndpoint}/${key}`,
-    }, arg !== undefined ? {args: arg} : null));
-  }
+    this.queuePush(
+      Object.assign(
+        {
+          address: `${this.controlEndpoint}/${key}`,
+        },
+        arg !== undefined ? { args: arg } : null
+      )
+    );
+  };
 });
-
-module.exports = Wekinator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "commitizen": "^4.0.0",
         "cz-conventional-changelog": "^3.0.0",
-        "jest": "^27.0.6",
+        "jest": "^27.3.1",
         "semantic-release": "^18.0.0"
       }
     },
@@ -2338,7 +2338,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2378,13 +2378,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2890,7 +2890,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/ci-info": {
       "version": "3.2.0",
@@ -3060,7 +3060,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3187,7 +3187,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/conventional-changelog-angular": {
       "version": "5.0.13",
@@ -3556,7 +3556,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -4209,7 +4209,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4461,7 +4461,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -4816,7 +4816,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -10581,7 +10581,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -10593,7 +10593,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11669,7 +11669,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11939,7 +11939,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -11953,7 +11953,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12532,7 +12532,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
@@ -14601,7 +14601,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "devOptional": true
+      "optional": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -14632,13 +14632,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "devOptional": true
+      "optional": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -15024,7 +15024,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "devOptional": true
+      "optional": true
     },
     "ci-info": {
       "version": "3.2.0",
@@ -15159,7 +15159,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "devOptional": true
+      "optional": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -15263,7 +15263,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "devOptional": true
+      "optional": true
     },
     "conventional-changelog-angular": {
       "version": "5.0.13",
@@ -15551,7 +15551,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "devOptional": true
+      "optional": true
     },
     "deprecation": {
       "version": "2.3.1",
@@ -16043,7 +16043,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -16241,7 +16241,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "devOptional": true
+      "optional": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -16506,7 +16506,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -20760,7 +20760,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -20772,7 +20772,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "devOptional": true
+      "optional": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -21569,7 +21569,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "devOptional": true
+      "optional": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -21795,7 +21795,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -21806,7 +21806,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -22265,7 +22265,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.0-development",
   "description": "An SDK to interface with Wekinator over OSC",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "semantic-release": "semantic-release"
   },
   "author": "Hugh Rawlinson <hugh@codeoclock.net>",
@@ -21,9 +22,9 @@
     "osc": "^2.3.0"
   },
   "devDependencies": {
-    "cz-conventional-changelog": "^3.0.0",
     "commitizen": "^4.0.0",
-    "jest": "^27.0.6",
+    "cz-conventional-changelog": "^3.0.0",
+    "jest": "^27.3.1",
     "semantic-release": "^18.0.0"
   },
   "config": {
@@ -35,5 +36,8 @@
     "branches": [
       "main"
     ]
+  },
+  "jest": {
+    "transform": {}
   }
 }


### PR DESCRIPTION
This isn't working unfortunately, because Jest's support for ESM codebases without transforming to commonjs is experimental, and I don't feel enthusiastic about bringing babel in. Right now the issue is that it's failing to mock the `osc` module. I tried using `unsafe_mockModule` and no the tests failed with saying that the port is already in use, so evidently it didn't mock it.